### PR TITLE
Set `type` attribute of registButton to `button`.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -182,6 +182,7 @@ export default class AnyButton {
         this.nodes.linkInput.dataset.placeholder = this.api.i18n.t('Link Url');
 
         this.nodes.registButton = this.make('button',[this.api.styles.button, this.CSS.registButton]);
+        this.nodes.registButton.type = 'button';
         this.nodes.registButton.textContent = this.api.i18n.t('Set');
 
 


### PR DESCRIPTION
> Otherwise it will try to submit form data and to load the (nonexistent) response, possibly destroying the current state of the document.
>
> https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type